### PR TITLE
ImportError: keras.optimizers.legacy

### DIFF
--- a/nonlincausality/nonlincausality.py
+++ b/nonlincausality/nonlincausality.py
@@ -246,7 +246,7 @@ def run_nonlincausality(
                 )
             # Training models for specified number of epochs and learning rate
             for i, e in enumerate(epochs_num):
-                opt = keras.optimizers.legacy.Adam(learning_rate=learning_rate[i])
+                opt = keras.optimizers.Adam(learning_rate=learning_rate[i])
                 model_X.compile(
                     optimizer=opt, loss="mean_squared_error", metrics=["mse"]
                 )


### PR DESCRIPTION
I get this error. Calling Adam like that is not compatible anymore for Keras 3. 

ImportError: keras.optimizers.legacy is not supported in Keras 3. When using tf.keras, to continue using a tf.keras.optimizers.legacy optimizer, you can install the tf_keras package (Keras 2) and set the environment variable TF_USE_LEGACY_KERAS=True to configure TensorFlow to use tf_keras when accessing tf.keras.